### PR TITLE
Improvements (trx receipt, variable RPC methods, RPC error type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ intents-sdk [command] --u ./sample.json
 ### Available Flags
 
 - `--u`: User operation JSON as string or path to a JSON file.
-- `--z`: Use zero gas mode, default is `false`.
 
 ### Cleaning Up
 

--- a/cmd/send_sign_userop.go
+++ b/cmd/send_sign_userop.go
@@ -70,5 +70,6 @@ func signAndSendUserOp(chainID *big.Int, bundlerUrl string, address, entryPointA
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("sign and send userOps resp: ", resp)
+	userOpHash := string(resp)
+	fmt.Println("sign and send userOps resp: ", userOpHash)
 }

--- a/cmd/send_sign_userop.go
+++ b/cmd/send_sign_userop.go
@@ -51,14 +51,14 @@ var SendAndSignUserOpCmd = &cobra.Command{
 		fmt.Printf("userOp:%s\n\n", unsignedUserOp.GetUserOpHash(entrypointAddr, chainID).String())
 
 		// Sign and send the user operation.
-		signAndSendUserOp(chainID, bundlerUrl, sender, entrypointAddr, eoaSigner, unsignedUserOp)
+		signAndSendUserOp(chainID, bundlerUrl, entrypointAddr, eoaSigner, unsignedUserOp)
 		// Print signature
 		utils.PrintSignature(userOp)
 	},
 }
 
 // signAndSendUserOp signs a user operation and then sends it.
-func signAndSendUserOp(chainID *big.Int, bundlerUrl string, address, entryPointAddr common.Address, signer *signer.EOA, userOp *model.UserOperation) {
+func signAndSendUserOp(chainID *big.Int, bundlerUrl string, entryPointAddr common.Address, signer *signer.EOA, userOp *model.UserOperation) {
 	// Sign user operation.
 	signedUserOps, err := userop.Sign(chainID, entryPointAddr, signer, userOp)
 	if err != nil {
@@ -72,4 +72,11 @@ func signAndSendUserOp(chainID *big.Int, bundlerUrl string, address, entryPointA
 	}
 	userOpHash := string(resp)
 	fmt.Println("sign and send userOps resp: ", userOpHash)
+
+	receipt, err := httpclient.GetUserOperationReceipt(bundlerUrl, userOpHash)
+	if err != nil {
+		fmt.Println("Error getting UserOperation receipt:", err)
+		return
+	}
+	fmt.Println("UserOperation Receipt:", string(receipt))
 }

--- a/cmd/send_sign_userop.go
+++ b/cmd/send_sign_userop.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/blndgs/model"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+	"github.com/stackup-wallet/stackup-bundler/pkg/signer"
+
 	"github.com/blndgs/intents-sdk/pkg/config"
 	"github.com/blndgs/intents-sdk/pkg/ethclient"
 	"github.com/blndgs/intents-sdk/pkg/httpclient"
 	"github.com/blndgs/intents-sdk/pkg/userop"
 	"github.com/blndgs/intents-sdk/utils"
-	"github.com/blndgs/model"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/spf13/cobra"
-	"github.com/stackup-wallet/stackup-bundler/pkg/signer"
 )
 
 // init initializes the sendAndSignUserOp command and adds it to the root command.
@@ -30,9 +31,6 @@ var SendAndSignUserOpCmd = &cobra.Command{
 		userOp := utils.GetUserOps(cmd)
 		fmt.Println("send and sign userOp:", userOp)
 
-		zeroGas := utils.IsZeroGas(cmd)
-		fmt.Println("is zero gas enabled: ", zeroGas)
-
 		sender := userOp.Sender
 		fmt.Println("sender address: ", sender)
 		// Initialize Ethereum client and retrieve nonce and chain ID.
@@ -42,7 +40,7 @@ var SendAndSignUserOpCmd = &cobra.Command{
 		if err != nil {
 			panic(err)
 		}
-		unsignedUserOp := utils.UpdateUserOp(userOp, nonce, zeroGas)
+		unsignedUserOp := utils.UpdateUserOp(userOp, nonce)
 
 		chainID, err := ethClient.GetChainID(sender)
 		if err != nil {

--- a/cmd/send_userop.go
+++ b/cmd/send_userop.go
@@ -63,5 +63,7 @@ func sendUserOp(chainID *big.Int, bundlerUrl string, entryPointAddr common.Addre
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println("send user Ops response: ", resp)
+
+	userOpHash := string(resp)
+	fmt.Println("sign and send userOps resp: ", userOpHash)
 }

--- a/cmd/send_userop.go
+++ b/cmd/send_userop.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/blndgs/model"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/spf13/cobra"
+	"github.com/stackup-wallet/stackup-bundler/pkg/signer"
+
 	"github.com/blndgs/intents-sdk/pkg/config"
 	"github.com/blndgs/intents-sdk/pkg/ethclient"
 	"github.com/blndgs/intents-sdk/pkg/httpclient"
 	"github.com/blndgs/intents-sdk/pkg/userop"
 	"github.com/blndgs/intents-sdk/utils"
-	"github.com/blndgs/model"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/spf13/cobra"
-	"github.com/stackup-wallet/stackup-bundler/pkg/signer"
 )
 
 // init initializes the sendUserOp command and adds it to the root command.
@@ -30,9 +31,6 @@ var SendUserOpCmd = &cobra.Command{
 		userOp := utils.GetUserOps(cmd)
 		fmt.Println("send userOp:", userOp)
 
-		zeroGas := utils.IsZeroGas(cmd)
-		fmt.Println("is zero gas enabled: ", zeroGas)
-
 		sender := userOp.Sender
 		fmt.Println("sender address: ", sender)
 
@@ -42,27 +40,26 @@ var SendUserOpCmd = &cobra.Command{
 		if err != nil {
 			panic(err)
 		}
-		unsignedUserOp := utils.UpdateUserOp(userOp, nonce, zeroGas)
+		unsignedUserOp := utils.UpdateUserOp(userOp, nonce)
 
 		chainID, err := ethClient.GetChainID(sender)
 		if err != nil {
 			panic(err)
 		}
-		sendUserOp(chainID, bundlerUrl, sender, entrypointAddr, eoaSigner, unsignedUserOp)
-		// Print signature
+
+		sendUserOp(chainID, bundlerUrl, entrypointAddr, eoaSigner, unsignedUserOp)
 		utils.PrintSignature(userOp)
 	},
 }
 
 // sendUserOp verifies the signature of the user operation and then sends it.
-func sendUserOp(chainID *big.Int, bundlerUrl string, address, entryPointAddr common.Address, signer *signer.EOA, signedUserOp *model.UserOperation) {
+func sendUserOp(chainID *big.Int, bundlerUrl string, entryPointAddr common.Address, signer *signer.EOA, signedUserOp *model.UserOperation) {
 	// verify signature
 	if !userop.VerifySignature(chainID, signer.PublicKey, entryPointAddr, signedUserOp) {
 		panic("Signature is invalid")
 	}
 	// send user ops
 	resp, err := httpclient.SendUserOp(bundlerUrl, entryPointAddr, signedUserOp)
-
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/send_userop.go
+++ b/cmd/send_userop.go
@@ -66,4 +66,11 @@ func sendUserOp(chainID *big.Int, bundlerUrl string, entryPointAddr common.Addre
 
 	userOpHash := string(resp)
 	fmt.Println("sign and send userOps resp: ", userOpHash)
+
+	receipt, err := httpclient.GetUserOperationReceipt(bundlerUrl, userOpHash)
+	if err != nil {
+		fmt.Println("Error getting UserOperation receipt:", err)
+		return
+	}
+	fmt.Println("UserOperation Receipt:", string(receipt))
 }

--- a/cmd/sign_userop.go
+++ b/cmd/sign_userop.go
@@ -30,10 +30,6 @@ var SignUserOpCmd = &cobra.Command{
 		nodeUrl, _, entrypointAddr, eoaSigner := config.ReadConf()
 		userOp := utils.GetUserOps(cmd)
 
-		zeroGas := utils.IsZeroGas(cmd)
-
-		fmt.Println("is zero gas enabled: ", zeroGas)
-
 		sender := userOp.Sender
 
 		fmt.Println("sender address: ", sender)
@@ -47,7 +43,7 @@ var SignUserOpCmd = &cobra.Command{
 		}
 
 		fmt.Println("nonce: ", nonce)
-		unsignedUserOp := utils.UpdateUserOp(userOp, nonce, zeroGas)
+		unsignedUserOp := utils.UpdateUserOp(userOp, nonce)
 		fmt.Println("unsignedUserOp: ", unsignedUserOp.String())
 		chainID, err := ethClient.GetChainID(sender)
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.21.5
 
 require (
 	github.com/ethereum/go-ethereum v1.13.8
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.18.2
 	github.com/stackup-wallet/stackup-bundler v0.6.32

--- a/utils/common.go
+++ b/utils/common.go
@@ -14,22 +14,13 @@ import (
 
 // AddCommonFlags adds common flags to the provided Cobra command.
 // It adds a string flag 'userop' for user operation JSON and
-// a boolean flag 'zerogas' to enable zero gas mode.
 func AddCommonFlags(cmd *cobra.Command) {
 	cmd.Flags().String("u", "", "User operation JSON")
-	cmd.Flags().Bool("z", true, "Use zero gas mode")
 
 	// Mark the 'userop' flag as required
 	if err := cmd.MarkFlagRequired("u"); err != nil {
 		panic(err)
 	}
-}
-
-// IsZeroGas checks if the 'zerogas' flag is set in the command.
-// It returns true if the 'zerogas' flag is set, otherwise false.
-func IsZeroGas(cmd *cobra.Command) bool {
-	zeroGas, _ := cmd.Flags().GetBool("z")
-	return zeroGas
 }
 
 // GetUserOps parses the 'userop' JSON string or file provided in the command flags
@@ -66,10 +57,9 @@ func GetUserOps(cmd *cobra.Command) *model.UserOperation {
 	return &userOp
 }
 
-// UpdateUserOp updates the given user operation based on the provided nonce and zeroGas flag.
-// If zeroGas is true, all gas-related fields in the user operation are set to zero.
+// UpdateUserOp updates the given user operation based on the provided nonce flag.
 // The function returns the updated UserOperation object.
-func UpdateUserOp(userOp *model.UserOperation, nonce *big.Int, zeroGas bool) *model.UserOperation {
+func UpdateUserOp(userOp *model.UserOperation, nonce *big.Int) *model.UserOperation {
 	zero := big.NewInt(0)
 
 	// set sane default values
@@ -83,10 +73,6 @@ func UpdateUserOp(userOp *model.UserOperation, nonce *big.Int, zeroGas bool) *mo
 		userOp.PreVerificationGas = big.NewInt(65536)
 	}
 
-	if zeroGas {
-		userOp.MaxFeePerGas = zero
-		userOp.MaxPriorityFeePerGas = zero
-	}
 	userOp.Nonce = nonce
 	return userOp
 }


### PR DESCRIPTION
- **Return transaction receipt if supported**
- **refactor: Remove zero gas flag**: Realized user needs to set only `maxFeePerGas` to zero for same effect
- **refactor: RPC requester to allow variable method requests**
- **feat: Add RPC type error to return when appropriate**
