### PR TITLE
Fix logs not getting written to an output

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/blndgs/intents-sdk/cmd"
@@ -15,6 +16,8 @@ func main() {
 		Short: "Intents SDK Command Line Interface",
 		Long:  `Intents SDK CLI provides tools for signing and sending user operations.`,
 	}
+
+	log.SetOutput(os.Stdout)
 
 	// Add commands to the root command
 	rootCmd.AddCommand(cmd.SendAndSignUserOpCmd)

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -83,7 +83,7 @@ func GetUserOperationReceipt(bundlerURL string, userOpHash string) (json.RawMess
 	params := []interface{}{userOpHash}
 	resp, err := SendRPCRequest(bundlerURL, "eth_getUserOperationReceipt", params)
 	if err != nil {
-		var rpcError RPCErrDetail
+		rpcError := &RPCErrDetail{}
 		if errors.As(err, &rpcError) {
 			if rpcError.Code == -32601 {
 				println("Cannot query receipt, check that the Ethereum node supports `getLogs`")


### PR DESCRIPTION
In between debugging connections to the bundler and setting up `anvil` locally to work with this,
log outputs are totally lost in transition and making it harder to get work done.