### PR TITLE
Fix to use --c <chain> for single userOps

### DIFF
--- a/cmd/hash_userop.go
+++ b/cmd/hash_userop.go
@@ -50,7 +50,7 @@ var HashUserOpCmd = &cobra.Command{
 			return config.NewError("failed to create user operation processor", err)
 		}
 
-		if err := p.setOpHashes(userOps, Offline); err != nil {
+		if err := p.setXOpHashes(userOps, Offline); err != nil {
 			return config.NewError("failed to set operation hashes", err)
 		}
 

--- a/cmd/userop_processor.go
+++ b/cmd/userop_processor.go
@@ -67,7 +67,7 @@ func NewUserOpProcessor(userOps []*model.UserOperation, nodes config.NodesMap, b
 	}, nil
 }
 
-func (p *UserOpProcessor) setOpHashes(userOps []*model.UserOperation, submissionAction SubmissionType) error {
+func (p *UserOpProcessor) setXOpHashes(userOps []*model.UserOperation, submissionAction SubmissionType) error {
 	for i, op := range userOps {
 		var hash common.Hash
 		if len(p.ProvidedHashes) > i && p.ProvidedHashes[i] != (common.Hash{}) {
@@ -120,7 +120,7 @@ func (p *UserOpProcessor) setOpHashes(userOps []*model.UserOperation, submission
 }
 
 func (p *UserOpProcessor) ProcessUserOps(userOps []*model.UserOperation, submissionAction SubmissionType) error {
-	if err := p.setOpHashes(userOps, submissionAction); err != nil {
+	if err := p.setXOpHashes(userOps, submissionAction); err != nil {
 		return config.NewError("error setting UserOperation hashes", err)
 	}
 	println()

--- a/cmd/userop_processor.go
+++ b/cmd/userop_processor.go
@@ -67,6 +67,11 @@ func NewUserOpProcessor(userOps []*model.UserOperation, nodes config.NodesMap, b
 	}, nil
 }
 
+// setXOpHashes sets the hash values for the UserOperations. If the hashes are provided, they are used.
+// If the submissionAction is online, the EIP-4337 nonce is set for the UserOperation.
+// If the UserOperation is a cross-chain operation, the hash is generated from the provided hashes.
+// If the UserOperation is a cross-chain operation and the submissionAction is BundlerSubmit or DirectSubmit,
+// the cross-chain data is parsed from the callData or signature and the hash is generated from the operation hashes.
 func (p *UserOpProcessor) setXOpHashes(userOps []*model.UserOperation, submissionAction SubmissionType) error {
 	for i, op := range userOps {
 		var hash common.Hash
@@ -119,6 +124,9 @@ func (p *UserOpProcessor) setXOpHashes(userOps []*model.UserOperation, submissio
 	return nil
 }
 
+// ProcessUserOps processes the UserOperations by setting the UserOperation hashes,
+// signing the UserOperations, and submitting the UserOperations to the bundler or
+// directly to the Ethereum node.
 func (p *UserOpProcessor) ProcessUserOps(userOps []*model.UserOperation, submissionAction SubmissionType) error {
 	if err := p.setXOpHashes(userOps, submissionAction); err != nil {
 		return config.NewError("error setting UserOperation hashes", err)


### PR DESCRIPTION
- **A bit of documentation**
- **fix: Use --c chain argument for single userOps**
- **refactor: rename setOpHashes**
- **refactor: split setXOpHashes to improve maintainability**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced hash retrieval and processing for user operations, including cross-chain functionality.
	- Added methods for improved nonce management and hash generation.

- **Bug Fixes**
	- Updated error messages for better clarity in handling user operations.

- **Refactor**
	- Renamed and refined methods for setting and caching operation hashes to improve code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->